### PR TITLE
finalize-release requires final_name rather than name

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,4 +1,4 @@
 ---
-name: aide
+final_name: aide
 blobstore:
   provider: s3


### PR DESCRIPTION
## Changes proposed in this pull request:

- use final_name rather than name because that's what finalize release expects

## Security considerations

None