### PR TITLE
Run report, check report has run

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This release is made with the following assumptions:
 - you're using the [node_exporter](https://github.com/bosh-prometheus/node-exporter-boshrelease) bosh release to export stats to prometheus
 - node_exporter is loading /var/vcap/data/node_exporer/config/.&ast;.prom
 
-To use this release, install it, then schedule `run-report.sh` via cron. You probably want to use the [cron boshrelease](https://github.com/cloudfoundry-community/cron-boshrelease)
-for this, but nobody's gonna force you to. [RedHat](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using-aide)
- says you should run AIDE at least weekly, but not more than daily.
+The release will schedule AIDE to check and report hourly, by dropping a file into `/etc/cron.hourly`.
 
 Extra rules can be applied via the `aide_rules` property, which should be just raw text rules:
 

--- a/jobs/aide/monit
+++ b/jobs/aide/monit
@@ -1,0 +1,3 @@
+check file aide-report-ran with path /var/vcap/data/aide/report-ran
+  if timestamp > 2 hours then alert
+  group vcap

--- a/jobs/aide/templates/bin/post-start
+++ b/jobs/aide/templates/bin/post-start
@@ -4,3 +4,7 @@ PATH=/var/vcap/packages/aide/bin:$PATH
 
 aide --update
 mv /var/vcap/store/aide/conf/aide.db.new /var/vcap/store/aide/conf/aide.db
+
+cp /var/vcap/jobs/aide/bin/run-report.sh /etc/cron.hourly/run-report.sh
+chmod 0700 /var/vcap/data/aide/report-ran.sh
+chown root: /var/vcap/data/aide/report-ran.sh

--- a/jobs/aide/templates/bin/run-report.sh.erb
+++ b/jobs/aide/templates/bin/run-report.sh.erb
@@ -15,8 +15,17 @@ logger -t aide.report -f report.txt
 # report has lines like:
 #           Added entries:     74
 added=$(grep 'Added entries:' report.txt | awk '{ print $3 }')
+if [[ -z "${added}" ]]; then
+    added=0
+fi
 removed=$(grep 'Removed entries:' report.txt | awk '{ print $3 }')
+if [[ -z "${removed}" ]]; then
+    removed=0
+fi
 changed=$(grep 'Changed entries:' report.txt | awk '{ print $3 }')
+if [[ -z "${changed}" ]]; then
+    changed=0
+fi
 
 echo 'aide_violation_count {action="added"}' ${added} > aide.prom
 echo 'aide_violation_count {action="removed"}' ${removed} >> aide.prom


### PR DESCRIPTION
## Changes proposed in this pull request:

- run the report hourly via cron
- make monit check that the report has been running
- set added/changed/removed to 0 when they're unset

*note*: this makes aide run hourly. [Redhat says](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using-aide)  you should run AIDE at least weekly, but _not more than daily_ . I don't see any reason running hourly would be bad, and I think a 24 hour feedback loop is too slow for anything that creates alerts

## Security considerations

None