### PR TITLE
Aide improvements

### DIFF
--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -8,14 +8,12 @@ LOGFILE=/var/vcap/sys/log/aide/report.log
 
 $PACKAGE_DIR/bin/aide --check > report.txt
 
-date >> ${LOGFILE}
-cat report.txt >> ${LOGFILE}
-echo "=============================================" >> ${LOGFILE}
-
 # aide exits nonzero when it finds a modification, so wait until here to set -e
 set -e
 
-logger -t aide.report -f report.txt
+date >> ${LOGFILE}
+cat report.txt >> ${LOGFILE}
+echo "=============================================" >> ${LOGFILE}
 
 # report has lines like:
 #           Added entries:     74

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -4,8 +4,13 @@ set -x
 
 JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
+LOGFILE=/var/vcap/sys/log/aide/report.log
 
 $PACKAGE_DIR/bin/aide --check > report.txt
+
+date >> ${LOGFILE}
+cat report.txt >> ${LOGFILE}
+echo "=============================================" >> ${LOGFILE}
 
 # aide exits nonzero when it finds a modification, so wait until here to set -e
 set -e

--- a/jobs/aide/templates/conf/aide.conf.erb
+++ b/jobs/aide/templates/conf/aide.conf.erb
@@ -24,7 +24,7 @@
 #tiger:  tiger checksum
 #haval:  haval checksum
 #crc32:  crc32 checksum
-#R:      p+ftupe+i+l+n+u+g+s+m+c+md5
+#R:      p+ftype+i+l+n+u+g+s+m+c+md5
 #L:      p+ftype+i+l+n+u+g
 #E:      Empty group
 #>:      Growing file p+ftype+l+u+g+i+n+S
@@ -43,6 +43,7 @@
 TEMPFILE = p+ftype+u+g
 # this is L from above, but without inode checks
 LNOI = p+ftype+l+n+u+g
+RNOI = p+ftype+l+n+u+g+s+m+c+md5
 
 # don't mess with AIDE
 /var/vcap/packages/aide R
@@ -58,13 +59,13 @@ LNOI = p+ftype+l+n+u+g
 
 # etc stuff
 # Bosh messes with all these, really
-/etc p+ftype+i+l+n+u+g+s+md5
-/etc/hosts      LNOI
-/etc/g?shadow-? LNOI
-/etc/group-?    LNOI
-/etc/passwd-?   LNOI
-/etc/subgid-?   LNOI
-/etc/subuid-?   LNOI
+/etc            RNOI
+#/etc/hosts      LNOI
+#/etc/g?shadow-? LNOI
+#/etc/group-?    LNOI
+#/etc/passwd-?   LNOI
+#/etc/subgid-?   LNOI
+#/etc/subuid-?   LNOI
 
 # bosh-specific
 /var/vcap/packages R


### PR DESCRIPTION
## Changes proposed in this pull request:

- Check user/group files in `/etc` more strictly
- Log AIDE reports to logfiles expected by BOSH, so we get log ingestion and rotation for free
- don't log to syslog, since we're getting ingestion by BOSH

## Security considerations

improves security by stricter file checking and better reporting.