### PR TITLE
copy file to cron.hourly before running system scan

### DIFF
--- a/jobs/aide/templates/bin/post-deploy
+++ b/jobs/aide/templates/bin/post-deploy
@@ -2,9 +2,10 @@
 
 PATH=/var/vcap/packages/aide/bin:$PATH
 
-aide --update
-mv /var/vcap/store/aide/conf/aide.db.new /var/vcap/store/aide/conf/aide.db
-
 cp /var/vcap/jobs/aide/bin/run-report /etc/cron.hourly/run-report
 chmod 0700 /etc/cron.hourly/run-report
 chown root: /etc/cron.hourly/run-report
+
+aide --update
+mv /var/vcap/store/aide/conf/aide.db.new /var/vcap/store/aide/conf/aide.db
+


### PR DESCRIPTION
## Changes proposed in this pull request:

- Create the cron script before running the baseline scan, otherwise the subsequent scans report on the cron script

## Security considerations

None