### PR TITLE
Fix update-aide-db script

### DIFF
--- a/jobs/aide/templates/bin/update-aide-db
+++ b/jobs/aide/templates/bin/update-aide-db
@@ -11,7 +11,7 @@ release_lock() {
 }
 
 initialize_lock() {
-  exec ${LOCKFD}<>${LOCKFILE}
+  eval "exec ${LOCKFD}<>${LOCKFILE}"
   trap release_lock EXIT
 }
 
@@ -22,5 +22,5 @@ update_aide() {
 
 initialize_lock
 
-flock -x -w 120 ${LOCKFD} -c update_aide
+flock -x -w 120 ${LOCKFD} && update_aide
 


### PR DESCRIPTION

## Changes proposed in this pull request:

- eval exec call, so interpolation doesn't confuse it
- flock && update_aide instead of flock -c update_aide, since update isn't a command

## Security considerations

None