### PR TITLE
run report when post-deploy runs

### DIFF
--- a/jobs/aide/spec
+++ b/jobs/aide/spec
@@ -7,6 +7,7 @@ templates:
   bin/post-deploy: bin/post-deploy
   bin/run-report.erb: bin/run-report
   bin/update-aide-db: bin/update-aide-db
+  bin/lock-functions: bin/lock-functions
 
 packages:
 - aide

--- a/jobs/aide/templates/bin/lock-functions
+++ b/jobs/aide/templates/bin/lock-functions
@@ -1,0 +1,17 @@
+LOCKFILE="/var/vcap/sys/run/aide/update.lock"
+LOCKFD=99
+
+release_lock() {
+  flock -u ${LOCKFD}
+  flock -xn ${LOCKFD} && rm -f ${LOCKFILE}
+}
+
+initialize_lock() {
+  eval "exec ${LOCKFD}<>${LOCKFILE}"
+  trap release_lock EXIT
+}
+
+update_aide() {
+  aide --update
+  mv /var/vcap/store/aide/conf/aide.db.new /var/vcap/store/aide/conf/aide.db
+}

--- a/jobs/aide/templates/bin/post-deploy
+++ b/jobs/aide/templates/bin/post-deploy
@@ -5,3 +5,4 @@ chmod 0700 /etc/cron.hourly/run-report
 chown root: /etc/cron.hourly/run-report
 
 /var/vcap/jobs/aide/bin/update-aide-db
+/var/vcap/jobs/aide/bin/run-report

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -6,7 +6,20 @@ JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
 LOGFILE=/var/vcap/sys/log/aide/report.log
 
-$PACKAGE_DIR/bin/aide --check > report.txt
+LOCKFILE="/var/vcap/sys/run/aide/update.lock"
+LOCKFD=99
+
+release_lock() {
+  flock -u ${LOCKFD}
+  flock -xn ${LOCKFD} && rm -f ${LOCKFILE}
+}
+
+initialize_lock() {
+  eval "exec ${LOCKFD}<>${LOCKFILE}"
+  trap release_lock EXIT
+}
+
+flock -x -w 120 ${LOCKFD} -c $PACKAGE_DIR/bin/aide --check > report.txt
 
 # aide exits nonzero when it finds a modification, so wait until here to set -e
 set -e

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -6,9 +6,7 @@ JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
 LOGFILE=/var/vcap/sys/log/aide/report.log
 
-pushd "${JOB_DIR}/bin"
-  source lock-functions
-popd
+source ${JOB_DIR}/bin/lock-functions
 
 initialize_lock
 

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -6,7 +6,7 @@ JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
 LOGFILE=/var/vcap/sys/log/aide/report.log
 
-pushd "$(dirname "${BASH_SOURCE[0]}")"
+pushd "${JOB_DIR}/bin"
   source lock-functions
 popd
 

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -6,18 +6,11 @@ JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
 LOGFILE=/var/vcap/sys/log/aide/report.log
 
-LOCKFILE="/var/vcap/sys/run/aide/update.lock"
-LOCKFD=99
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+  source lock-functions
+popd
 
-release_lock() {
-  flock -u ${LOCKFD}
-  flock -xn ${LOCKFD} && rm -f ${LOCKFILE}
-}
-
-initialize_lock() {
-  eval "exec ${LOCKFD}<>${LOCKFILE}"
-  trap release_lock EXIT
-}
+initialize_lock
 
 flock -x -w 120 ${LOCKFD} -c $PACKAGE_DIR/bin/aide --check > report.txt
 

--- a/jobs/aide/templates/bin/update-aide-db
+++ b/jobs/aide/templates/bin/update-aide-db
@@ -2,25 +2,10 @@
 
 PATH=/var/vcap/packages/aide/bin:$PATH
 
-LOCKFILE="/var/vcap/sys/run/aide/update.lock"
-LOCKFD=99
-
-release_lock() {
-  flock -u ${LOCKFD}
-  flock -xn ${LOCKFD} && rm -f ${LOCKFILE}
-}
-
-initialize_lock() {
-  eval "exec ${LOCKFD}<>${LOCKFILE}"
-  trap release_lock EXIT
-}
-
-update_aide() {
-  aide --update
-  mv /var/vcap/store/aide/conf/aide.db.new /var/vcap/store/aide/conf/aide.db
-}
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+  source lock-functions
+popd
 
 initialize_lock
 
 flock -x -w 120 ${LOCKFD} && update_aide
-


### PR DESCRIPTION
## Changes proposed in this pull request:

- run aide report upon deployment
- move lock functions to source-able file

running the report upon deployment is something I've gone back and forth on - it certainly makes iterating on AIDE easier, and will fix some weirdness with errand VMs, but it seems a little weird to mess with the normal cadence of AIDE metrics.

## Security considerations

None