### PR TITLE
will the last script leaving AIDE please turn off the lights

### DIFF
--- a/jobs/aide/templates/bin/lock-functions
+++ b/jobs/aide/templates/bin/lock-functions
@@ -3,7 +3,7 @@ LOCKFD=99
 
 release_lock() {
   flock -u ${LOCKFD}
-  flock -xn ${LOCKFD} && rm -f ${LOCKFILE}
+  flock -xn ${LOCKFD} && rm -f ${LOCKFILE} || /bin/true
 }
 
 initialize_lock() {


### PR DESCRIPTION
## Changes proposed in this pull request:

- force success code when releasing locks. This is because we try to unlock on exit, and doing that requests an exclusive lock. This fails if something else grabbed the lock between us releasing it and trying to grab it again. It's safe to ignore because presumably whatever grabbed the lock with eventually release it and delete the lock file

## Security considerations

None