### PR TITLE
Ignore aide lock file when performing `run-report` via cron

### DIFF
--- a/jobs/aide/templates/conf/aide.conf.erb
+++ b/jobs/aide/templates/conf/aide.conf.erb
@@ -73,6 +73,8 @@ RNOIMC = p+ftype+l+n+u+g+s+md5
 !/var/vcap/sys/log/.*
 /var/vcap/sys/run TEMPFILE
 
+# Ignore aide's own lock file which changes file permissions when run
+!/var/vcap/sys/run/aide/update.lock$
 
 # binaries and libraries
 /usr                     R


### PR DESCRIPTION
## Changes proposed in this pull request:

- While checking other aide warnings noticed that periodically aide snags on its own lock file for permission changes, this specifically ignores the file `/var/vcap/sys/run/aide/update.lock` but otherwise leaves intact the scanning of `/var/vcap/sys/run/`
- Tested manually by editing an `aide.conf` file, running the post-deploy script and then the run-report script, the report comes up clean now. 
- I'll update the instructions for clearing a false positive aide alert, the ones in place only clear the alert until the next cron cycle that runs the run-report making the person on maintenance very sad after thinking they had cleared the alerts.
- Part of maintenance: https://github.com/cloud-gov/private/issues/618

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

Should reduce false positive aide alerts
