### PR TITLE
Rnoc

### DIFF
--- a/jobs/aide/templates/conf/aide.conf.erb
+++ b/jobs/aide/templates/conf/aide.conf.erb
@@ -70,7 +70,8 @@ RNOC = p+ftype+i+l+n+u+g+s+m+md5
 /etc/sv/agent/supervise    TEMPFILE
 
 # bosh-specific
-/var/vcap/data/packages RNOC
+/var/vcap/data/packages$ RNOC
+/var/vcap/data/packages R
 !/var/vcap/sys/log/.*
 /var/vcap/sys/run TEMPFILE
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a new pattern called `RNOC` which is the value of `R` minus ctime (aka `c`), this pattern is then applied to the directory named `/var/vcap/data/packages`.  Why?  Because when a bosh director is recreated and performs a background inventory, it contacts the bosh agent and results in changes to the folder seen as:

   ```
   Directory: /var/vcap/data/packages
    Ctime     : 2025-10-06 12:20:38 +0000        | 2025-10-28 16:12:09 +0000
    ```
- First rule match is the winner, so apply the pattern to the folder first, the rest of the files IN the folder remain the same `R` scan as before (see the line below the one added).
 - Annoyingly, this impacts every vm managed by a director that has been upgraded on a subsequent run-report cron run.
 - Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This only changes excluding ctime changes on a single directory, not the contents of the directory, blast pattern is pretty small.
