### PR TITLE
Separate calculate-changes into a function and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,44 @@ prepend_rules: |
 
 ## What it does
 
-Pre-start scripts ensure the AIDE db has been initialized.
-Post-start scripts update the database, accepting all changes.
-run-report.sh runs aide --check and exports the results to prometheus
+ - `pre-start` script ensures the AIDE db has been initialized.
+ - `post-deploy` script updates the database calling `update-aide-db`, accepting all changes and schedules a cron job to hourly run aide checks.
+ - `run-report` runs aide --check, calling functions in `lock-functions` and `calculate-changes`,  and exports the results to prometheus
+
+## Running tests
+
+There are a subset of files and conditions which are ignored when an `aide --check` command is executed because of `bosh ssh`.  Details on this are located at https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Platform/aide.md#adding-files-to-be-ignored---alerting-only
+
+To test the function which calculates the number of changes, execute the file `jobs/aide/templates/bin/test-calculate-changes.sh` which should be located in the same folder is `calculate-changes`.  The output should be similar to:
+
+```bash
+./test-calculate-changes
+Running calculate_changes tests...
+======================================
+=== Testing scenario: scenario1_bosh_changes_only ===
+✓ PASS: Scenario 1: bosh_ changes only - Result: 0 (expected: 0)
+
+=== Testing scenario: scenario2_non_bosh_changes ===
+✓ PASS: Scenario 2: non-bosh changes - Result: 1 (expected: 1)
+
+=== Testing scenario: scenario3_outside_allowed_list ===
+✓ PASS: Scenario 3: files outside allowed list - Result: 3 (expected: 3)
+
+=== Testing scenario: scenario4_zero_changes ===
+✓ PASS: Scenario 4: zero changes - Result: 0 (expected: 0)
+
+=== Testing scenario: scenario5_invalid_report ===
+✓ PASS: Scenario 5: invalid report format - Result: 0 (expected: 0)
+
+=== Testing scenario: scenario6_mixed_changes ===
+✓ PASS: Scenario 6: mixed bosh_ and non-bosh_ changes - Result: 1 (expected: 1)
+
+======================================
+         TEST SUMMARY
+======================================
+Total tests:  6
+Passed:       6
+Failed:       0
+
+All tests passed!
+```

--- a/jobs/aide/spec
+++ b/jobs/aide/spec
@@ -8,6 +8,7 @@ templates:
   bin/run-report.erb: bin/run-report
   bin/update-aide-db: bin/update-aide-db
   bin/lock-functions: bin/lock-functions
+  bin/calculate-changes: bin/calculate-changes
 
 packages:
 - aide

--- a/jobs/aide/templates/bin/calculate-changes
+++ b/jobs/aide/templates/bin/calculate-changes
@@ -1,0 +1,202 @@
+#!/bin/bash
+
+calculate_changes() {
+    # Function parameters
+    local LOGFILE=$1
+    local REPORT_FILE=${2:-"report.txt"}  # Default to report.txt if not specified
+    local TEST_MODE=${3:-"false"}         # Test mode flag
+    local TEST_FILES_DIR=${4:-""}         # Directory containing test files
+    
+    # Initialize the changed variable
+    local changed=0
+    
+    # Define the allowed files
+    local allowed_files=(
+        "/etc/group-"
+        "/etc/gshadow-"
+        "/etc/passwd-"
+        "/etc/shadow-"
+        "/etc/subgid-"
+        "/etc/subuid-"
+        "/etc/group"
+        "/etc/gshadow"
+        "/etc/passwd"
+        "/etc/shadow"
+        "/etc/subgid"
+        "/etc/subuid"
+    )
+    
+    # If in test mode, override with test paths
+    if [ "$TEST_MODE" = "true" ] && [ -n "$TEST_FILES_DIR" ]; then
+        echo "TEST_MODE is true" >> ${LOGFILE}
+        allowed_files=(
+            "${TEST_FILES_DIR}/group-"
+            "${TEST_FILES_DIR}/gshadow-"
+            "${TEST_FILES_DIR}/passwd-"
+            "${TEST_FILES_DIR}/shadow-"
+            "${TEST_FILES_DIR}/subgid-"
+            "${TEST_FILES_DIR}/subuid-"
+            "${TEST_FILES_DIR}/group"
+            "${TEST_FILES_DIR}/gshadow"
+            "${TEST_FILES_DIR}/passwd"
+            "${TEST_FILES_DIR}/shadow"
+            "${TEST_FILES_DIR}/subgid"
+            "${TEST_FILES_DIR}/subuid"
+        )
+    fi
+    
+    # Extract the number of changed entries
+    local changed_entries=$(grep "Changed entries:" "$REPORT_FILE" | grep -v "^Changed entries:$" | awk '{print $3}')
+    echo "Calculating changes for Prometheus..." >> ${LOGFILE}
+    echo "Changed entries found by aide --check: ${changed_entries}" >> ${LOGFILE}
+    
+    # Check if changed_entries is empty or not a number
+    if [ -z "$changed_entries" ] || ! [[ "$changed_entries" =~ ^[0-9]+$ ]]; then
+        # If we can't extract a valid number, default to 0
+        echo "Error: Could not extract valid number of changed entries" >> ${LOGFILE}
+        changed=0
+    else
+        # If changed entries is 0, set changed=0
+        if [ "$changed_entries" -eq 0 ]; then
+            changed=0
+        else
+            # Extract the list of changed files
+            local changed_files=$(awk '
+                /^Changed entries:$/ { in_section = 1; next }
+                in_section && /^f > / { 
+                    # Extract filename after the colon and space
+                    idx = index($0, ": ")
+                    if (idx > 0) {
+                        filename = substr($0, idx + 2)
+                        # Remove any trailing whitespace or special characters
+                        gsub(/[[:space:]]+$/, "", filename)
+                        print filename
+                    }
+                }
+                in_section && /^---/ && prev_line ~ /^$/ { exit }
+                { prev_line = $0 }
+            ' "$REPORT_FILE")
+            
+            # Print the changed files (one per line for visibility)
+            echo "Changed files:" >> ${LOGFILE}
+            echo "$changed_files" >> ${LOGFILE}
+            
+            # Check if any changed files are outside the allowed list
+            local files_outside_list=false
+            while IFS= read -r file; do
+                if [ -n "$file" ]; then
+                    local is_allowed=false
+                    for allowed in "${allowed_files[@]}"; do
+                        if [ "$file" = "$allowed" ]; then
+                            is_allowed=true
+                            break
+                        fi
+                    done
+                    if [ "$is_allowed" = false ]; then
+                        echo "File outside allowed list: $file" >> ${LOGFILE}
+                        files_outside_list=true
+                        break
+                    fi
+                fi
+            done <<< "$changed_files"
+            
+            # If there are files outside the allowed list, set changed to the number of changed entries
+            if [ "$files_outside_list" = true ]; then
+                echo "There were changes outside of the allowed list..." >> ${LOGFILE}
+                changed=$changed_entries
+            else
+                echo "All file changes are in the allowed list, checking diffs..." >> ${LOGFILE}
+                # All files are in the allowed list, now check diffs for bosh_ differences
+                # Group the files into pairs (base and dash versions)
+                local base_files=(
+                    "/etc/group"
+                    "/etc/gshadow"
+                    "/etc/passwd"
+                    "/etc/shadow"
+                    "/etc/subgid"
+                    "/etc/subuid"
+                )
+                
+                # If in test mode, override with test paths
+                if [ "$TEST_MODE" = "true" ] && [ -n "$TEST_FILES_DIR" ]; then
+                    base_files=(
+                        "${TEST_FILES_DIR}/group"
+                        "${TEST_FILES_DIR}/gshadow"
+                        "${TEST_FILES_DIR}/passwd"
+                        "${TEST_FILES_DIR}/shadow"
+                        "${TEST_FILES_DIR}/subgid"
+                        "${TEST_FILES_DIR}/subuid"
+                    )
+                fi
+                
+                for base_file in "${base_files[@]}"; do
+                    local dash_file="${base_file}-"
+                    
+                    # Check if the file is in the base or dash file list
+                    if echo "$changed_files" | grep -q "^${base_file}$" || echo "$changed_files" | grep -q "^${dash_file}$"; then
+                        echo "Checking diff for $base_file and $dash_file" >> ${LOGFILE}
+                        # Check if both files exist on the system
+                        if [ -f "$base_file" ] && [ -f "$dash_file" ]; then
+                            # Perform diff and check for non-bosh_ differences
+                            set +e
+                            local diff_output=$(diff "$dash_file" "$base_file" 2>/dev/null || true)
+                            
+                            if [ -n "$diff_output" ]; then
+                                # Extract lines from dash_file (lines starting with <)
+                                local dash_lines=$(echo "$diff_output" | grep "^<" | sed 's/^< //')
+                                # Extract lines from base_file (lines starting with >)
+                                local base_lines=$(echo "$diff_output" | grep "^>" | sed 's/^> //')
+                                
+                                # Check if all dash_file lines contain bosh_ (only if there are dash lines)
+                                local all_dash_have_bosh=true
+                                if [ -n "$dash_lines" ]; then
+                                    while IFS= read -r line; do
+                                        if ! echo "$line" | grep -q "bosh_"; then
+                                            all_dash_have_bosh=false
+                                            break
+                                        fi
+                                    done <<< "$dash_lines"
+                                else
+                                    # No dash lines, so set to false to not trigger the ignore condition
+                                    all_dash_have_bosh=false
+                                fi
+                                
+                                # Check if all base_file lines contain bosh_ (only if there are base lines)
+                                local all_base_have_bosh=true
+                                if [ -n "$base_lines" ]; then
+                                    while IFS= read -r line; do
+                                        if ! echo "$line" | grep -q "bosh_"; then
+                                            all_base_have_bosh=false
+                                            break
+                                        fi
+                                    done <<< "$base_lines"
+                                else
+                                    # No base lines, so set to false to not trigger the ignore condition
+                                    all_base_have_bosh=false
+                                fi
+                                
+                                # If EITHER all dash lines OR all base lines contain bosh_ (and they exist), don't count as change
+                                if { [ -n "$dash_lines" ] && [ "$all_dash_have_bosh" = true ]; } || { [ -n "$base_lines" ] && [ "$all_base_have_bosh" = true ]; }; then
+                                    echo "All lines in at least one side contain bosh_ in $base_file - not counting as change" >> ${LOGFILE}
+                                else
+                                    echo "Found changes without bosh_ in both sides for $base_file" >> ${LOGFILE}
+                                    ((changed++))
+                                fi
+                            else
+                                echo "No differences found between $dash_file and $base_file" >> ${LOGFILE}
+                            fi
+                            set -e
+                        else
+                            # If files don't exist for diff, count it as a change
+                            echo "Warning: Cannot diff $base_file and $dash_file - one or both files missing" >> ${LOGFILE}
+                            ((changed++))
+                        fi
+                    fi
+                done
+            fi
+        fi
+    fi
+    
+    # Return the changed value
+    echo "$changed"
+}

--- a/jobs/aide/templates/bin/run-report.erb
+++ b/jobs/aide/templates/bin/run-report.erb
@@ -6,6 +6,9 @@ JOB_DIR=/var/vcap/jobs/aide
 PACKAGE_DIR=/var/vcap/packages/aide
 LOGFILE=/var/vcap/sys/log/aide/report.log
 
+# Source the calculate_changes function
+source ${JOB_DIR}/bin/calculate-changes
+
 source ${JOB_DIR}/bin/lock-functions
 
 initialize_lock
@@ -28,158 +31,15 @@ if [[ -z "${removed}" ]]; then
     removed=0
 fi
 
-# New logic for calculating changed entries
-# Initialize the changed variable
-changed=0
+# Call the calculate_changes function
+changed=$(calculate_changes "$LOGFILE")
 
-# Define the allowed files
-allowed_files=(
-    "/etc/group-"
-    "/etc/gshadow-"
-    "/etc/passwd-"
-    "/etc/shadow-"
-    "/etc/subgid-"
-    "/etc/subuid-"
-    "/etc/group"
-    "/etc/gshadow"
-    "/etc/passwd"
-    "/etc/shadow"
-    "/etc/subgid"
-    "/etc/subuid"
-)
+# Add what was reported to Prometheus to the logs
+echo 'aide_violation_count {action="added"}' ${added} >> ${LOGFILE}
+echo 'aide_violation_count {action="removed"}' ${removed} >> ${LOGFILE}
+echo 'aide_violation_count {action="changed"}' ${changed} >> ${LOGFILE}
 
-# Extract the number of changed entries
-changed_entries=$(grep "Changed entries:" report.txt | grep -v "^Changed entries:$" | awk '{print $3}')
-echo "Changed entries found by aide --check: ${changed_entries}"
-
-# Check if changed_entries is empty or not a number
-if [ -z "$changed_entries" ] || ! [[ "$changed_entries" =~ ^[0-9]+$ ]]; then
-    # If we can't extract a valid number, default to 0
-    echo "Error: Could not extract valid number of changed entries"
-    changed=0
-else
-    # If changed entries is 0, set changed=0
-    if [ "$changed_entries" -eq 0 ]; then
-        changed=0
-    else
-        # Extract the list of changed files
-        changed_files=$(awk '
-            /^Changed entries:$/ { in_section = 1; next }
-            in_section && /^f > / { 
-                # Extract filename after the colon and space
-                idx = index($0, ": ")
-                if (idx > 0) {
-                    filename = substr($0, idx + 2)
-                    # Remove any trailing whitespace or special characters
-                    gsub(/[[:space:]]+$/, "", filename)
-                    print filename
-                }
-            }
-            in_section && /^---/ && prev_line ~ /^$/ { exit }
-            { prev_line = $0 }
-        ' report.txt)
-        # Print the changed files (one per line for visibility)
-        echo "Changed files:"
-        echo "$changed_files"
-
-        # Check if any changed files are outside the allowed list
-        files_outside_list=false
-        while IFS= read -r file; do
-            if [ -n "$file" ]; then
-                is_allowed=false
-                for allowed in "${allowed_files[@]}"; do
-                    if [ "$file" = "$allowed" ]; then
-                        is_allowed=true
-                        break
-                    fi
-                done
-                if [ "$is_allowed" = false ]; then
-                    echo "File outside allowed list: $file"
-                    files_outside_list=true
-                    break
-                fi
-            fi
-        done <<< "$changed_files"
-
-        # If there are files outside the allowed list, set changed to the number of changed entries
-        if [ "$files_outside_list" = true ]; then
-            echo "There were changes outside of the allowed list..."
-            changed=$changed_entries
-        else
-             echo "All file changes are in the allowed list, checking diffs..."
-            # All files are in the allowed list, now check diffs for bosh_ differences
-            # Group the files into pairs (base and dash versions)
-            base_files=(
-                "/etc/group"
-                "/etc/gshadow"
-                "/etc/passwd"
-                "/etc/shadow"
-                "/etc/subgid"
-                "/etc/subuid"
-            )
-            
-            for base_file in "${base_files[@]}"; do
-                dash_file="${base_file}-"
-                
-                # Check if both files exist in the changed files list
-                if echo "$changed_files" | grep -q "^${base_file}$" || echo "$changed_files" | grep -q "^${dash_file}$"; then
-                    echo "Checking diff for $base_file and $dash_file"
-                    # Check if both files exist on the system
-                    if [ -f "$base_file" ] && [ -f "$dash_file" ]; then
-                        # Perform diff and check for non-bosh_ differences
-                        set +e
-                        diff_output=$(diff "$dash_file" "$base_file" 2>/dev/null || true)
-                        
-                        if [ -n "$diff_output" ]; then
-                            # Extract lines from dash_file (lines starting with <)
-                            dash_lines=$(echo "$diff_output" | grep "^<" | sed 's/^< //')
-                            # Extract lines from base_file (lines starting with >)
-                            base_lines=$(echo "$diff_output" | grep "^>" | sed 's/^> //')
-                            
-                            # Check if all dash_file lines contain bosh_
-                            all_dash_have_bosh=true
-                            if [ -n "$dash_lines" ]; then
-                                while IFS= read -r line; do
-                                    if ! echo "$line" | grep -q "bosh_"; then
-                                        all_dash_have_bosh=false
-                                        break
-                                    fi
-                                done <<< "$dash_lines"
-                            fi
-                            
-                            # Check if all base_file lines contain bosh_
-                            all_base_have_bosh=true
-                            if [ -n "$base_lines" ]; then
-                                while IFS= read -r line; do
-                                    if ! echo "$line" | grep -q "bosh_"; then
-                                        all_base_have_bosh=false
-                                        break
-                                    fi
-                                done <<< "$base_lines"
-                            fi
-                            
-                            # If EITHER all dash lines OR all base lines contain bosh_, don't count as change
-                            if [ "$all_dash_have_bosh" = true ] || [ "$all_base_have_bosh" = true ]; then
-                                echo "All lines in at least one side contain bosh_ in $base_file - not counting as change"
-                            else
-                                echo "Found changes without bosh_ in both sides for $base_file"
-                                ((changed++))
-                            fi
-                        else
-                            echo "No differences found between $dash_file and $base_file"
-                        fi
-                        set -e
-                    else
-                        # If files don't exist for diff, count it as a change
-                        echo "Warning: Cannot diff $base_file and $dash_file - one or both files missing"
-                        ((changed++))
-                    fi
-                fi
-            done
-        fi
-    fi
-fi
-
+# Write out the aide.prom file which is read by node-exporter
 echo 'aide_violation_count {action="added"}' ${added} > aide.prom
 echo 'aide_violation_count {action="removed"}' ${removed} >> aide.prom
 echo 'aide_violation_count {action="changed"}' ${changed} >> aide.prom

--- a/jobs/aide/templates/bin/test-calculate-changes.sh
+++ b/jobs/aide/templates/bin/test-calculate-changes.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+
+# Source the function
+source ./calculate-changes
+
+# Create test directory structure
+TEST_DIR="./test_scenarios"
+mkdir -p "$TEST_DIR"
+
+# Test counters
+TOTAL_TESTS=0
+FAILED_TESTS=0
+PASSED_TESTS=0
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to create a test scenario
+create_test_scenario() {
+    local scenario_name=$1
+    local scenario_dir="${TEST_DIR}/${scenario_name}"
+    mkdir -p "$scenario_dir"
+    
+    # Create log file for this scenario
+    local log_file="${scenario_dir}/test.log"
+    > "$log_file"
+    
+    echo "=== Testing scenario: $scenario_name ===" | tee -a "$log_file"
+}
+
+# Function to check test result
+check_test_result() {
+    local test_name=$1
+    local actual=$2
+    local expected=$3
+    local log_file=$4
+    
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    
+    if [ "$actual" -eq "$expected" ]; then
+        echo -e "${GREEN}✓ PASS${NC}: $test_name - Result: $actual (expected: $expected)" | tee -a "$log_file"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+        return 0
+    else
+        echo -e "${RED}✗ FAIL${NC}: $test_name - Result: $actual (expected: $expected)" | tee -a "$log_file"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        return 1
+    fi
+}
+
+# ######################################################################################
+# Scenario 1: Test with only bosh_ changes, changed files are in the allowed list only
+# ######################################################################################
+
+test_scenario_1() {
+    local scenario="scenario1_bosh_changes_only"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     2
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario1_bosh_changes_only/passwd
+f > .: ./test_scenarios/scenario1_bosh_changes_only/group
+
+---------------------------------------------------
+EOF
+    
+    # Create test files with bosh_ changes
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd-"
+    echo "bosh_user1:x:1001:1001::/home/bosh_user1:/bin/bash" >> "${scenario_dir}/passwd-"
+    
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd"
+    echo "bosh_user1:x:1001:1001::/home/bosh_user1:/bin/bash" >> "${scenario_dir}/passwd"
+    echo "bosh_user2:x:1002:1002::/home/bosh_user2:/bin/bash" >> "${scenario_dir}/passwd"
+    
+    echo "root:x:0:" > "${scenario_dir}/group-"
+    echo "bosh_group1:x:1001:" >> "${scenario_dir}/group-"
+    
+    echo "root:x:0:" > "${scenario_dir}/group"
+    echo "bosh_group1:x:1001:" >> "${scenario_dir}/group"
+    echo "bosh_group2:x:1002:" >> "${scenario_dir}/group"
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 1: bosh_ changes only" "$result" "0" "$log_file"
+}
+
+
+# ######################################################################################
+# Scenario 2: Test with non-bosh changes, changed file is in allowed list
+# ######################################################################################
+test_scenario_2() {
+    local scenario="scenario2_non_bosh_changes"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     1
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario2_non_bosh_changes/passwd
+
+---------------------------------------------------
+EOF
+    
+    # Create test files with non-bosh changes
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd-"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd-"
+    
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd"
+    echo "user2:x:1002:1002::/home/user2:/bin/bash" >> "${scenario_dir}/passwd"
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 2: non-bosh changes" "$result" "1" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 3: Test with mixed files inside and outside allowed list
+# ######################################################################################
+test_scenario_3() {
+    local scenario="scenario3_outside_allowed_list"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     3
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: /etc/hosts
+f > .: ./test_scenarios/scenario3_outside_allowed_list/passwd
+f > .: /var/log/syslog
+
+---------------------------------------------------
+EOF
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 3: files outside allowed list" "$result" "3" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 4: Test with zero changes
+# ######################################################################################
+test_scenario_4() {
+    local scenario="scenario4_zero_changes"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     0
+
+---------------------------------------------------
+EOF
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 4: zero changes" "$result" "0" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 5: Test with invalid report format
+# ######################################################################################
+test_scenario_5() {
+    local scenario="scenario5_invalid_report"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt with invalid format
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+This is not a valid AIDE report
+EOF
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 5: invalid report format" "$result" "0" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 6: Test with mixed bosh_ and non-bosh_ changes, files are all in allowed list
+# ######################################################################################
+test_scenario_6() {
+    local scenario="scenario6_mixed_changes"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+    
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     2
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario6_mixed_changes/passwd
+f > .: ./test_scenarios/scenario6_mixed_changes/group
+
+---------------------------------------------------
+EOF
+    
+    # Create passwd files with non-bosh changes
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd-"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd-"
+    
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd"
+    echo "user2:x:1002:1002::/home/user2:/bin/bash" >> "${scenario_dir}/passwd"
+    
+    # Create group files with bosh_ changes only
+    echo "root:x:0:" > "${scenario_dir}/group-"
+    echo "bosh_group1:x:1001:" >> "${scenario_dir}/group-"
+    
+    echo "root:x:0:" > "${scenario_dir}/group"
+    echo "bosh_group1:x:1001:" >> "${scenario_dir}/group"
+    echo "bosh_group2:x:1002:" >> "${scenario_dir}/group"
+    
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 6: mixed bosh_ and non-bosh_ changes" "$result" "1" "$log_file"
+}
+
+# Function to print test summary
+print_test_summary() {
+    echo ""
+    echo "======================================"
+    echo "         TEST SUMMARY"
+    echo "======================================"
+    echo -e "Total tests:  ${YELLOW}$TOTAL_TESTS${NC}"
+    echo -e "Passed:       ${GREEN}$PASSED_TESTS${NC}"
+    echo -e "Failed:       ${RED}$FAILED_TESTS${NC}"
+    echo ""
+    
+    if [ $FAILED_TESTS -eq 0 ]; then
+        echo -e "${GREEN}All tests passed!${NC}"
+        return 0
+    else
+        echo -e "${RED}$FAILED_TESTS test(s) failed!${NC}"
+        echo ""
+        echo "Check individual test logs in ${TEST_DIR} for details."
+        return 1
+    fi
+}
+
+# Main test runner
+main() {
+    echo "Running calculate_changes tests..."
+    echo "======================================"
+    
+    # Run all test scenarios
+    test_scenario_1
+    echo ""
+    test_scenario_2
+    echo ""
+    test_scenario_3
+    echo ""
+    test_scenario_4
+    echo ""
+    test_scenario_5
+    echo ""
+    test_scenario_6
+    
+    # Print summary
+    print_test_summary
+    
+    # Exit with appropriate code
+    if [ $FAILED_TESTS -gt 0 ]; then
+        exit 1
+    else
+        exit 0
+    fi
+}
+
+# Run the tests
+main


### PR DESCRIPTION
## Changes proposed in this pull request:

- Separate calculate-changes into a function and add tests
- Tests exposed an edge case where the diff is only on one side without bosh_ in any of the lines being ignored.  Tests are good things.
- `echo` output sent to the log file `/var/vcap/sys/log/aide/report.log`
- Updates to README on how to run tests and clarity on what scripts are doing
- Part of https://github.com/cloud-gov/product/issues/2836

## Security considerations

Decreases false positives sent to prometheus with respect to aide
