### PR TITLE
Add check for bosh agent updating vcap password

### DIFF
--- a/jobs/aide/templates/bin/test-calculate-changes.sh
+++ b/jobs/aide/templates/bin/test-calculate-changes.sh
@@ -309,8 +309,6 @@ EOF
     check_test_result "Scenario 8: shadow changes" "$result" "1" "$log_file"
 }
 
-
-
 # Function to print test summary
 print_test_summary() {
     echo ""
@@ -354,7 +352,7 @@ main() {
     test_scenario_7
     echo ""
     test_scenario_8
-    
+
     # Print summary
     print_test_summary
     


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds testing for edge case where the BOSH director is updated, the bosh agents on the VM respond back on the first pass and get a new timestamp for the vcap password without changing the password in the /etc/shadow file.
- Adds two new tests to `test-calculate-changes`
- Reduces false positives in Prometheus
- Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Reduces false positives.  This is an expected behavior of the bosh agent when a bosh director is upgraded.
