### PR TITLE
aide: ignore /etc/sysctl.conf hardening drift when route.flush marker is last line

### DIFF
--- a/jobs/aide/templates/bin/calculate-changes
+++ b/jobs/aide/templates/bin/calculate-changes
@@ -24,7 +24,15 @@ calculate_changes() {
         "/etc/shadow"
         "/etc/subgid"
         "/etc/subuid"
+        "/etc/sysctl.conf"
     )
+
+    # The sysctl.conf file is allowed to change when the OS hardening script
+    # re-applies its ruleset on deploy. Its expected end-of-file marker line is
+    # tracked separately because it has no dash (backup) counterpart to diff
+    # against like the passwd/shadow family does.
+    local sysctl_file="/etc/sysctl.conf"
+    local sysctl_marker="net.ipv4.route.flush=1"
     
     # If in test mode, override with test paths
     if [ "$TEST_MODE" = "true" ] && [ -n "$TEST_FILES_DIR" ]; then
@@ -42,7 +50,9 @@ calculate_changes() {
             "${TEST_FILES_DIR}/shadow"
             "${TEST_FILES_DIR}/subgid"
             "${TEST_FILES_DIR}/subuid"
+            "${TEST_FILES_DIR}/sysctl.conf"
         )
+        sysctl_file="${TEST_FILES_DIR}/sysctl.conf"
     fi
     
     # Extract the number of changed entries
@@ -106,7 +116,30 @@ calculate_changes() {
                 changed=$changed_entries
             else
                 echo "All file changes are in the allowed list, checking diffs..." >> ${LOGFILE}
-                # All files are in the allowed list, now check diffs for bosh_ differences
+
+                # Handle /etc/sysctl.conf separately: the OS hardening script
+                # re-applies its ruleset on deploy, ending the file with the
+                # marker line. If sysctl.conf changed, only skip it when the
+                # last non-empty line equals the expected marker; otherwise
+                # count it as a real change.
+                if echo "$changed_files" | grep -q -E "(^| )${sysctl_file}( |$)"; then
+                    echo "Checking sysctl.conf end-of-file marker for $sysctl_file" >> ${LOGFILE}
+                    if [ -f "$sysctl_file" ]; then
+                        # Last non-empty (non-whitespace-only) line, trailing whitespace stripped
+                        local sysctl_last_line=$(grep -vE '^[[:space:]]*$' "$sysctl_file" | tail -n 1 | sed 's/[[:space:]]*$//')
+                        if [ "$sysctl_last_line" = "$sysctl_marker" ]; then
+                            echo "Ignoring change for $sysctl_file: last non-empty line is the expected marker '${sysctl_marker}'." >> ${LOGFILE}
+                        else
+                            echo "Found change in $sysctl_file: last non-empty line ('${sysctl_last_line}') is not the expected marker '${sysctl_marker}'. Counting as change." >> ${LOGFILE}
+                            ((changed++))
+                        fi
+                    else
+                        echo "Warning: Cannot check $sysctl_file - file missing. Counting as change." >> ${LOGFILE}
+                        ((changed++))
+                    fi
+                fi
+
+                # All file changes are in the allowed list, now check diffs for bosh_ differences
                 # Group the files into pairs (base and dash versions)
                 local base_files=(
                     "/etc/group"

--- a/jobs/aide/templates/bin/test-calculate-changes.sh
+++ b/jobs/aide/templates/bin/test-calculate-changes.sh
@@ -310,6 +310,125 @@ EOF
 }
 
 
+# ######################################################################################
+# Scenario 9: /etc/sysctl.conf change where last non-empty line is the expected marker
+#             -> should be ignored (0)
+# ######################################################################################
+
+test_scenario_9() {
+    local scenario="scenario9_sysctl_marker_present"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     1
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario9_sysctl_marker_present/sysctl.conf
+
+---------------------------------------------------
+EOF
+
+    # sysctl.conf ending with the expected marker (plus trailing blank lines
+    # to prove the "last non-empty line" logic tolerates trailing whitespace)
+    cat > "${scenario_dir}/sysctl.conf" << 'EOF'
+kernel.randomize_va_space = 2
+net.ipv4.conf.all.rp_filter=1
+net.ipv4.tcp_syncookies=1
+net.ipv4.route.flush=1
+
+EOF
+
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 9: sysctl.conf with expected marker" "$result" "0" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 10: /etc/sysctl.conf change where last non-empty line is NOT the marker
+#              -> should be counted (1)
+# ######################################################################################
+
+test_scenario_10() {
+    local scenario="scenario10_sysctl_marker_absent"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     1
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario10_sysctl_marker_absent/sysctl.conf
+
+---------------------------------------------------
+EOF
+
+    # sysctl.conf NOT ending with the expected marker
+    cat > "${scenario_dir}/sysctl.conf" << 'EOF'
+kernel.randomize_va_space = 2
+net.ipv4.route.flush=1
+net.ipv4.ip_forward=1
+EOF
+
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 10: sysctl.conf without expected marker as last line" "$result" "1" "$log_file"
+}
+
+# ######################################################################################
+# Scenario 11: sysctl.conf (marker present, ignored) combined with a non-bosh passwd
+#              change (counted) -> only the passwd change counts (1)
+# ######################################################################################
+
+test_scenario_11() {
+    local scenario="scenario11_sysctl_marker_plus_passwd"
+    create_test_scenario "$scenario"
+    local scenario_dir="${TEST_DIR}/${scenario}"
+    local log_file="${scenario_dir}/test.log"
+
+    # Create test report.txt
+    cat > "${scenario_dir}/report.txt" << 'EOF'
+Changed entries:     2
+
+---------------------------------------------------
+Changed entries:
+---------------------------------------------------
+
+f > .: ./test_scenarios/scenario11_sysctl_marker_plus_passwd/sysctl.conf
+f > .: ./test_scenarios/scenario11_sysctl_marker_plus_passwd/passwd
+
+---------------------------------------------------
+EOF
+
+    # sysctl.conf ending with the expected marker -> ignored
+    cat > "${scenario_dir}/sysctl.conf" << 'EOF'
+kernel.randomize_va_space = 2
+net.ipv4.route.flush=1
+EOF
+
+    # passwd with a non-bosh change -> counted
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd-"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd-"
+
+    echo "root:x:0:0:root:/root:/bin/bash" > "${scenario_dir}/passwd"
+    echo "user1:x:1001:1001::/home/user1:/bin/bash" >> "${scenario_dir}/passwd"
+    echo "user2:x:1002:1002::/home/user2:/bin/bash" >> "${scenario_dir}/passwd"
+
+    # Run the test
+    local result=$(calculate_changes "$log_file" "${scenario_dir}/report.txt" "true" "$scenario_dir")
+    check_test_result "Scenario 11: sysctl.conf marker ignored + passwd counted" "$result" "1" "$log_file"
+}
+
 
 # Function to print test summary
 print_test_summary() {
@@ -354,6 +473,12 @@ main() {
     test_scenario_7
     echo ""
     test_scenario_8
+    echo ""
+    test_scenario_9
+    echo ""
+    test_scenario_10
+    echo ""
+    test_scenario_11
     
     # Print summary
     print_test_summary


### PR DESCRIPTION
The harden-boshrelease post-deploy re-applies its sysctl ruleset on every
deploy, appending hardening settings to /etc/sysctl.conf and terminating the
file with net.ipv4.route.flush=1. This triggers a benign AIDE change entry.

calculate-changes now allows /etc/sysctl.conf and skips the change only when
the last non-empty line of the live file equals net.ipv4.route.flush=1; any
other trailing content still counts. Adds test scenarios 9-11 (all 11 pass).

Refs cloud-gov/private#3051
